### PR TITLE
Add dependency instructions for RPM based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Discussion and support on IRC channel [#canaldev](http://webchat.freenode.net/?c
 
 On Debian based systems install following packages:
 
-    sudo apt-get install cmake valac libgee-0.8-dev
+    # apt-get install cmake valac libgee-0.8-dev
+    
+On RPM package manager based systems install following packages:
+    
+    # dnf install cmake valac libgee-devel
 
 ### Building ###
  1. `mkdir build && cd build`


### PR DESCRIPTION
This PR aims to provide dependencies instructions for Linux distributions using RPM package manager such as Fedora, CentOS, OpenSuse, Mageia, ROSA, ALT Linux, etc...

Opened this PR as I plan to use this cool library in Ricin soon :)